### PR TITLE
Modify import path not to use relative path

### DIFF
--- a/http_jubatus.go
+++ b/http_jubatus.go
@@ -2,7 +2,7 @@
 package main
 
 import (
-	"./process"
+	"github.com/kumagi/http_jubatus/process"
 	"code.google.com/p/go-uuid/uuid"
 	"encoding/json"
 	"fmt"


### PR DESCRIPTION
remote import path is useful for "go get"
